### PR TITLE
feat(settings): replace orphaned controls with working display, data …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,15 @@ jobs:
           STOCKWISE_SUPABASE_ENABLED: "false"
         run: |
           uvicorn "stockwise_api.api.app:create_app" --factory --app-dir src --host 0.0.0.0 --port 8000 &
-          sleep 3
-          curl -f http://localhost:8000/health
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health > /dev/null; then
+              echo "Backend ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Backend failed to start within 30s"
+          exit 1
 
       - name: Set up Node 20
         uses: actions/setup-node@v4

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,11 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Head from 'next/head';
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider } from '@/lib/auth';
 
+const DENSITY_KEY = 'stockwise-table-density';
+const DENSITY_VALUES = ['comfortable', 'compact', 'spacious'] as const;
+
 function App({ Component, pageProps }: AppProps) {
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem(DENSITY_KEY);
+            const density = (DENSITY_VALUES as readonly string[]).includes(stored ?? '')
+                ? (stored as typeof DENSITY_VALUES[number])
+                : 'comfortable';
+            document.documentElement.classList.add(`density-${density}`);
+        } catch {
+            // ignore storage failures (private mode, etc.)
+        }
+    }, []);
+
     return (
         <AuthProvider>
             <Head>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -1,207 +1,183 @@
 import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { Github, Shield, Trash2 } from 'lucide-react';
 import { NavigationBar } from '@/components/Dashboard';
-import { Button, Card, Input, Select, Alert } from '@/components/common';
+import { Button, Card, Select } from '@/components/common';
+import {
+    clearAnalysisHistory,
+    clearLatestAnalysisId,
+    getAnalysisHistory,
+    getLatestAnalysisId,
+} from '@/lib/analysisSession';
 
-const STORAGE_KEY = 'stockwise-settings';
+const DENSITY_KEY = 'stockwise-table-density';
 
-const defaultValues = {
-    defaultUsagePeriod: 'daily',
-    defaultExportFormat: 'csv',
-    tableDensity: 'comfortable',
-    showRecommendations: true,
-    showWasteAlerts: true,
-};
+type Density = 'comfortable' | 'compact' | 'spacious';
+
+const DENSITY_OPTIONS: Array<{ value: Density; label: string }> = [
+    { value: 'comfortable', label: 'Comfortable' },
+    { value: 'compact', label: 'Compact' },
+    { value: 'spacious', label: 'Spacious' },
+];
+
+function applyDensityClass(density: Density) {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.remove('density-comfortable', 'density-compact', 'density-spacious');
+    root.classList.add(`density-${density}`);
+}
 
 export default function SettingsPage() {
-    const [defaultUsagePeriod, setDefaultUsagePeriod] = useState(defaultValues.defaultUsagePeriod);
-    const [defaultExportFormat, setDefaultExportFormat] = useState(defaultValues.defaultExportFormat);
-    const [tableDensity, setTableDensity] = useState(defaultValues.tableDensity);
-    const [showRecommendations, setShowRecommendations] = useState(defaultValues.showRecommendations);
-    const [showWasteAlerts, setShowWasteAlerts] = useState(defaultValues.showWasteAlerts);
-    const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
+    const [density, setDensity] = useState<Density>('comfortable');
+    const [historyCount, setHistoryCount] = useState(0);
+    const [hasLatestAnalysis, setHasLatestAnalysis] = useState(false);
 
     useEffect(() => {
-        if (typeof window === 'undefined') return;
-        try {
-            const stored = localStorage.getItem(STORAGE_KEY);
-            if (!stored) return;
-            const parsed = JSON.parse(stored);
-            setDefaultUsagePeriod(parsed.defaultUsagePeriod ?? defaultValues.defaultUsagePeriod);
-            setDefaultExportFormat(parsed.defaultExportFormat ?? defaultValues.defaultExportFormat);
-            setTableDensity(parsed.tableDensity ?? defaultValues.tableDensity);
-            setShowRecommendations(parsed.showRecommendations ?? defaultValues.showRecommendations);
-            setShowWasteAlerts(parsed.showWasteAlerts ?? defaultValues.showWasteAlerts);
-        } catch {
-            // ignore invalid stored settings
-        }
+        const stored = (localStorage.getItem(DENSITY_KEY) as Density | null) ?? 'comfortable';
+        setDensity(stored);
+        applyDensityClass(stored);
     }, []);
 
-    const handleSave = () => {
-        try {
-            const settings = {
-                defaultUsagePeriod,
-                defaultExportFormat,
-                tableDensity,
-                showRecommendations,
-                showWasteAlerts,
-            };
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-            setSaveStatus('saved');
-            window.setTimeout(() => setSaveStatus('idle'), 3000);
-        } catch {
-            setSaveStatus('error');
-        }
+    useEffect(() => {
+        setHistoryCount(getAnalysisHistory().length);
+        setHasLatestAnalysis(Boolean(getLatestAnalysisId()));
+    }, []);
+
+    const handleDensityChange = (value: Density) => {
+        setDensity(value);
+        localStorage.setItem(DENSITY_KEY, value);
+        applyDensityClass(value);
+        toast.success(`Table density set to ${value}`);
     };
 
-    const handleReset = () => {
-        setDefaultUsagePeriod(defaultValues.defaultUsagePeriod);
-        setDefaultExportFormat(defaultValues.defaultExportFormat);
-        setTableDensity(defaultValues.tableDensity);
-        setShowRecommendations(defaultValues.showRecommendations);
-        setShowWasteAlerts(defaultValues.showWasteAlerts);
-        setSaveStatus('idle');
-        localStorage.removeItem(STORAGE_KEY);
+    const handleClearHistory = () => {
+        if (historyCount === 0) return;
+        if (!confirm(`Clear ${historyCount} entries from local history? This cannot be undone.`)) return;
+        clearAnalysisHistory();
+        setHistoryCount(0);
+        toast.success('Entry history cleared');
     };
+
+    const handleClearLatest = () => {
+        if (!hasLatestAnalysis) return;
+        if (!confirm('Clear the cached analysis ID? You will need to upload or enter data again to view a dashboard.')) return;
+        clearLatestAnalysisId();
+        setHasLatestAnalysis(false);
+        toast.success('Cached analysis cleared');
+    };
+
+    const githubRepo = process.env.NEXT_PUBLIC_GITHUB_REPO ?? 'https://github.com/shuheng0330/StockWise';
+    const frontendVersion = '0.1.0';
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
             <NavigationBar activeSection="settings" onFeatureSelect={() => null} />
 
-            <main className="max-w-6xl mx-auto p-4 md:p-8">
+            <main className="max-w-5xl mx-auto p-4 md:p-8">
                 <div className="mb-8">
-                    <h1 className="text-4xl font-bold text-slate-900">Settings</h1>
-                    <p className="mt-3 text-gray-600 max-w-2xl">
-                        Configure StockWise behavior for analysis defaults, export preferences, and display settings.
-                        These preferences are stored locally in your browser and help streamline future workflows.
+                    <h1 className="text-3xl md:text-4xl font-bold text-slate-900">Settings</h1>
+                    <p className="mt-2 text-gray-600 max-w-2xl text-sm md:text-base">
+                        Manage display preferences and locally cached data.
                     </p>
                 </div>
 
                 <div className="grid gap-6">
                     <Card className="p-6">
-                        <div className="flex flex-col gap-3">
-                            <h2 className="text-2xl font-semibold text-slate-900">Analysis Preferences</h2>
-                            <p className="text-sm text-gray-600">
-                                Choose default behaviors for newly created inventory analyses.
-                            </p>
-
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <Select
-                                    label="Default usage period"
-                                    value={defaultUsagePeriod}
-                                    onChange={(e) => setDefaultUsagePeriod(e.target.value)}
-                                    options={[
-                                        { value: 'daily', label: 'Daily' },
-                                        { value: 'weekly', label: 'Weekly' },
-                                    ]}
-                                />
-                                <Select
-                                    label="Default export format"
-                                    value={defaultExportFormat}
-                                    onChange={(e) => setDefaultExportFormat(e.target.value)}
-                                    options={[
-                                        { value: 'csv', label: 'CSV' },
-                                        { value: 'xlsx', label: 'XLSX' },
-                                        { value: 'pdf', label: 'PDF' },
-                                    ]}
-                                />
-                            </div>
-                        </div>
-                    </Card>
-
-                    <Card className="p-6">
-                        <div className="flex flex-col gap-3">
-                            <h2 className="text-2xl font-semibold text-slate-900">Display Preferences</h2>
-                            <p className="text-sm text-gray-600">
-                                Adjust table density and on-screen alerts to match your reporting style.
-                            </p>
-
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <Select
-                                    label="Table density"
-                                    value={tableDensity}
-                                    onChange={(e) => setTableDensity(e.target.value)}
-                                    options={[
-                                        { value: 'comfortable', label: 'Comfortable' },
-                                        { value: 'compact', label: 'Compact' },
-                                        { value: 'spacious', label: 'Spacious' },
-                                    ]}
-                                />
-
-                                <div className="space-y-3">
-                                    <div className="flex items-center justify-between gap-3 p-4 border rounded-lg bg-slate-50">
-                                        <div>
-                                            <p className="text-sm font-medium text-slate-900">Show recommendation warnings</p>
-                                            <p className="text-sm text-gray-600">Display alert labels for urgent restock and waste risk items.</p>
-                                        </div>
-                                        <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                                            <input
-                                                type="checkbox"
-                                                checked={showRecommendations}
-                                                onChange={(e) => setShowRecommendations(e.target.checked)}
-                                                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                            />
-                                        </label>
-                                    </div>
-
-                                    <div className="flex items-center justify-between gap-3 p-4 border rounded-lg bg-slate-50">
-                                        <div>
-                                            <p className="text-sm font-medium text-slate-900">Show waste risk alerts</p>
-                                            <p className="text-sm text-gray-600">Toggle on-screen notifications for high waste-risk inventory items.</p>
-                                        </div>
-                                        <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                                            <input
-                                                type="checkbox"
-                                                checked={showWasteAlerts}
-                                                onChange={(e) => setShowWasteAlerts(e.target.checked)}
-                                                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                                            />
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </Card>
-
-                    <Card className="p-6">
-                        <div className="flex flex-col gap-3">
-                            <h2 className="text-2xl font-semibold text-slate-900">Data & Export</h2>
-                            <p className="text-sm text-gray-600">Control how inventory reports are generated and exported from StockWise.</p>
-
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <Input
-                                    label="Preferred report name prefix"
-                                    value="stockwise-report"
-                                    readOnly
-                                />
-                                <Input
-                                    label="Default note for exports"
-                                    value="Inventory recommendations generated by StockWise"
-                                    readOnly
-                                />
-                            </div>
-                        </div>
-                    </Card>
-
-                    {saveStatus === 'saved' && (
-                        <Alert type="success" message="Settings saved locally in your browser." />
-                    )}
-                    {saveStatus === 'error' && (
-                        <Alert type="error" message="Unable to save settings. Please try again." />
-                    )}
-
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="space-x-3">
-                            <Button variant="primary" onClick={handleSave}>
-                                Save Settings
-                            </Button>
-                            <Button variant="secondary" onClick={handleReset}>
-                                Reset to Defaults
-                            </Button>
-                        </div>
-                        <p className="text-sm text-gray-600 max-w-2xl">
-                            These settings are for the current browser only. They are not tied to a user profile or login.
+                        <h2 className="text-xl font-semibold text-slate-900 mb-2">Display</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Choose how dense data tables appear across the app. Applies to the dashboard, records, and export tables.
                         </p>
-                    </div>
+                        <div className="max-w-xs">
+                            <Select
+                                label="Table density"
+                                value={density}
+                                onChange={(e) => handleDensityChange(e.target.value as Density)}
+                                options={DENSITY_OPTIONS}
+                            />
+                        </div>
+                    </Card>
+
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-2">Data Management</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Clear locally cached data stored by this browser. This does not affect your saved data on the server.
+                        </p>
+                        <div className="space-y-3">
+                            <div className="flex flex-wrap items-center justify-between gap-3 p-4 border rounded-lg bg-slate-50">
+                                <div>
+                                    <p className="text-sm font-medium text-slate-900">Entry history</p>
+                                    <p className="text-sm text-gray-600">
+                                        {historyCount === 0
+                                            ? 'No entries logged'
+                                            : `${historyCount} entr${historyCount === 1 ? 'y' : 'ies'} logged`}
+                                    </p>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    onClick={handleClearHistory}
+                                    disabled={historyCount === 0}
+                                    className="inline-flex items-center gap-2"
+                                >
+                                    <Trash2 className="w-4 h-4" />
+                                    Clear history
+                                </Button>
+                            </div>
+
+                            <div className="flex flex-wrap items-center justify-between gap-3 p-4 border rounded-lg bg-slate-50">
+                                <div>
+                                    <p className="text-sm font-medium text-slate-900">Cached latest analysis</p>
+                                    <p className="text-sm text-gray-600">
+                                        {hasLatestAnalysis
+                                            ? 'A cached analysis ID is stored'
+                                            : 'No cached analysis'}
+                                    </p>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    onClick={handleClearLatest}
+                                    disabled={!hasLatestAnalysis}
+                                    className="inline-flex items-center gap-2"
+                                >
+                                    <Trash2 className="w-4 h-4" />
+                                    Clear cache
+                                </Button>
+                            </div>
+                        </div>
+                    </Card>
+
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-3">About</h2>
+                        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm mb-4">
+                            <div className="p-3 border rounded-lg bg-slate-50">
+                                <dt className="text-xs uppercase tracking-wider text-gray-500">Frontend version</dt>
+                                <dd className="text-slate-900 font-medium mt-1">v{frontendVersion}</dd>
+                            </div>
+                            <div className="p-3 border rounded-lg bg-slate-50">
+                                <dt className="text-xs uppercase tracking-wider text-gray-500">Project</dt>
+                                <dd className="text-slate-900 font-medium mt-1">StockWise — UMHack 2026</dd>
+                            </div>
+                        </dl>
+                        <div className="flex flex-wrap gap-4 text-sm">
+                            <a
+                                href={githubRepo}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1.5 text-indigo-600 hover:underline"
+                            >
+                                <Github className="w-4 h-4" />
+                                GitHub repository
+                            </a>
+                            <a
+                                href={`${githubRepo}/blob/main/SECURITY.md`}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1.5 text-indigo-600 hover:underline"
+                            >
+                                <Shield className="w-4 h-4" />
+                                Security policy
+                            </a>
+                        </div>
+                    </Card>
                 </div>
             </main>
         </div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -21,3 +21,22 @@ body {
 code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+/* Table density preference (set from /settings, applied to <html> in _app.tsx) */
+html.density-comfortable td,
+html.density-comfortable th {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+}
+
+html.density-compact td,
+html.density-compact th {
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+}
+
+html.density-spacious td,
+html.density-spacious th {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
The previous Settings page saved 7 controls to localStorage but no other page read any of them — every control was dead code. This PR replaces it with 3 sections where every control performs a real action.

## What's new
- **Display** — table density (Comfortable/Compact/Spacious) actually changes table cell padding via a class on `<html>` + globals.css rules
- **Data Management** — clear entry history and clear cached analysis, delegating to existing `analysisSession` utilities
- **About** — frontend version + links to GitHub repo and SECURITY.md

## Why no Account / System Status sections
Both are already surfaced in the top navigation bar — no need to duplicate.

## Test plan
- [x] CI: backend pytest, frontend typecheck + Jest, Next production build all pass locally
- [ ] Smoke: change density at `/settings`, verify dashboard/records tables visibly change padding
- [ ] Smoke: clear history at `/settings`, verify counts go to zero and `/history` page shows empty state
- [ ] Smoke: density preference persists across page reloads
