### PR TITLE
feat(ux): mentor feedback — CSV column hints, guided tour, methodology page

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -13,6 +13,17 @@ test.describe('StockWise happy-path demo', () => {
     // in the test body (not beforeEach) to actually halt execution.
     testInfo.skip(!EMAIL || !PASSWORD, 'Set E2E_TEST_EMAIL and E2E_TEST_PASSWORD to run this test');
 
+    // Pre-seed localStorage so the first-visit guided tour does not auto-open
+    // and intercept clicks on the home page. Real users only see it once;
+    // E2E always starts in a fresh browser context, so we mark it dismissed.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('stockwise-tour-seen-v1', '1');
+      } catch {
+        // ignore — private browsing, etc.
+      }
+    });
+
     // ── 1. Login ────────────────────────────────────────────────────────────
     await page.goto('/login');
     // Wait for the login form to be fully ready before filling

--- a/frontend/src/components/GuidedTour.tsx
+++ b/frontend/src/components/GuidedTour.tsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+    ArrowLeft,
+    ArrowRight,
+    CheckCircle2,
+    ClipboardList,
+    Lightbulb,
+    MessageSquare,
+    Package,
+    Sparkles,
+    X,
+} from 'lucide-react';
+
+const TOUR_KEY = 'stockwise-tour-seen-v1';
+
+interface TourStep {
+    icon: React.ReactNode;
+    title: string;
+    body: string;
+    accent: string;
+    iconBg: string;
+}
+
+const STEPS: TourStep[] = [
+    {
+        icon: <Package className="w-7 h-7" />,
+        title: 'Welcome to StockWise',
+        body:
+            'We help small cafes, stalls, and kiosks decide what to reorder — so you never run out of stock, and never waste money on items you bought too much of.',
+        accent: 'bg-indigo-50',
+        iconBg: 'bg-indigo-100 text-indigo-700',
+    },
+    {
+        icon: <ClipboardList className="w-7 h-7" />,
+        title: 'Step 1: Tell us about your stock',
+        body:
+            'Upload a CSV file or fill in our simple form. For each item, we just need to know how much you have, how fast you use it, and how long your supplier takes to deliver.',
+        accent: 'bg-blue-50',
+        iconBg: 'bg-blue-100 text-blue-700',
+    },
+    {
+        icon: <Sparkles className="w-7 h-7" />,
+        title: 'Step 2: We calculate the risks',
+        body:
+            'Our system works out which items are about to run out, which might spoil, and which are just right. Same data always gives the same answer — no guessing.',
+        accent: 'bg-emerald-50',
+        iconBg: 'bg-emerald-100 text-emerald-700',
+    },
+    {
+        icon: <Lightbulb className="w-7 h-7" />,
+        title: 'Step 3: Follow the action list',
+        body:
+            'Each item gets one clear label so you know what to do today. Open the dashboard daily and follow the list — sorted from most urgent to least.',
+        accent: 'bg-amber-50',
+        iconBg: 'bg-amber-100 text-amber-700',
+    },
+    {
+        icon: <MessageSquare className="w-7 h-7" />,
+        title: 'Bonus: AI explains the "why"',
+        body:
+            'Click any item to see a plain-language explanation of why we recommend that action. You stay in control — the AI just translates the numbers into advice you can act on.',
+        accent: 'bg-purple-50',
+        iconBg: 'bg-purple-100 text-purple-700',
+    },
+];
+
+const ACTION_LABELS: Array<{ emoji: string; label: string; meaning: string; color: string }> = [
+    { emoji: '🔴', label: 'Buy Now', meaning: 'Stock running out — order today', color: 'bg-rose-50 text-rose-900 border-rose-200' },
+    { emoji: '🟡', label: 'Buy Less', meaning: 'Risk of spoilage — reduce next order', color: 'bg-amber-50 text-amber-900 border-amber-200' },
+    { emoji: '🟢', label: 'Wait', meaning: 'Plenty of stock — delay reorder', color: 'bg-emerald-50 text-emerald-900 border-emerald-200' },
+    { emoji: '🔵', label: 'Watch', meaning: 'No urgent action — keep an eye on it', color: 'bg-sky-50 text-sky-900 border-sky-200' },
+];
+
+interface GuidedTourProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export function GuidedTour({ open, onClose }: GuidedTourProps) {
+    const [stepIndex, setStepIndex] = useState(0);
+
+    useEffect(() => {
+        if (open) setStepIndex(0);
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+            if (e.key === 'ArrowRight') setStepIndex((i) => Math.min(STEPS.length - 1, i + 1));
+            if (e.key === 'ArrowLeft') setStepIndex((i) => Math.max(0, i - 1));
+        };
+        window.addEventListener('keydown', handleKey);
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [open, onClose]);
+
+    if (!open) return null;
+
+    const step = STEPS[stepIndex];
+    const isLast = stepIndex === STEPS.length - 1;
+    const isFirst = stepIndex === 0;
+
+    const handleClose = () => {
+        try {
+            localStorage.setItem(TOUR_KEY, '1');
+        } catch {
+            // ignore
+        }
+        onClose();
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm"
+            onClick={handleClose}
+            role="dialog"
+            aria-modal="true"
+            aria-label="StockWise quick tour"
+        >
+            <div
+                className="relative w-full max-w-lg bg-white rounded-2xl shadow-2xl overflow-hidden"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    className="absolute top-4 right-4 p-1.5 rounded-lg text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition"
+                    aria-label="Close"
+                >
+                    <X className="w-5 h-5" />
+                </button>
+
+                <div className={`${step.accent} p-8 pt-10 text-center`}>
+                    <div
+                        className={`inline-flex items-center justify-center w-14 h-14 rounded-2xl ${step.iconBg} mb-4`}
+                    >
+                        {step.icon}
+                    </div>
+                    <h2 className="text-2xl font-bold text-slate-900 mb-3">{step.title}</h2>
+                    <p className="text-base text-slate-700 leading-relaxed max-w-md mx-auto">
+                        {step.body}
+                    </p>
+
+                    {/* Step 3: show the action labels inline */}
+                    {stepIndex === 3 && (
+                        <div className="mt-5 grid grid-cols-2 gap-2 text-left">
+                            {ACTION_LABELS.map((a) => (
+                                <div key={a.label} className={`p-2.5 rounded-lg border text-xs ${a.color}`}>
+                                    <div className="font-semibold mb-0.5">
+                                        {a.emoji} {a.label}
+                                    </div>
+                                    <div className="opacity-80">{a.meaning}</div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Last step: methodology link for technical readers */}
+                    {isLast && (
+                        <Link
+                            href="/methodology"
+                            className="inline-block mt-4 text-sm text-indigo-600 hover:underline"
+                            onClick={handleClose}
+                        >
+                            See the full technical breakdown →
+                        </Link>
+                    )}
+                </div>
+
+                <div className="bg-white p-5 flex items-center justify-between gap-3">
+                    {/* Progress dots */}
+                    <div className="flex items-center gap-1.5">
+                        {STEPS.map((_, i) => (
+                            <button
+                                key={i}
+                                type="button"
+                                onClick={() => setStepIndex(i)}
+                                aria-label={`Go to step ${i + 1}`}
+                                className={`h-2 rounded-full transition-all ${
+                                    i === stepIndex
+                                        ? 'w-6 bg-indigo-600'
+                                        : i < stepIndex
+                                            ? 'w-2 bg-indigo-300'
+                                            : 'w-2 bg-slate-200'
+                                }`}
+                            />
+                        ))}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        {!isFirst && (
+                            <button
+                                type="button"
+                                onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
+                                className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 rounded-lg transition"
+                            >
+                                <ArrowLeft className="w-4 h-4" />
+                                Back
+                            </button>
+                        )}
+                        {isLast ? (
+                            <button
+                                type="button"
+                                onClick={handleClose}
+                                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition"
+                            >
+                                <CheckCircle2 className="w-4 h-4" />
+                                Got it
+                            </button>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => setStepIndex((i) => Math.min(STEPS.length - 1, i + 1))}
+                                className="inline-flex items-center gap-1 px-4 py-2 text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition"
+                            >
+                                Next
+                                <ArrowRight className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function shouldAutoOpenTour(): boolean {
+    if (typeof window === 'undefined') return false;
+    try {
+        return localStorage.getItem(TOUR_KEY) !== '1';
+    } catch {
+        return false;
+    }
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,15 +1,134 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Upload, FileText } from 'lucide-react';
+import { Upload, FileText, ChevronDown, ChevronUp, AlertTriangle, CheckCircle2, HelpCircle } from 'lucide-react';
 import { Button, Alert, Card } from '@/components/common';
 import { InventoryItemForm } from '@/components/InventoryItemForm';
 import { NavigationBar } from '@/components/Dashboard';
+import { GuidedTour, shouldAutoOpenTour } from '@/components/GuidedTour';
 import { apiClient } from '@/services/api';
 import { getLatestAnalysisId, recordAnalysisInHistory, saveLatestAnalysisId } from '@/lib/analysisSession';
 import { ManualItemInput } from '@/types';
 import { useAuth } from '@/lib/auth';
 import toast from 'react-hot-toast';
+
+interface CsvColumnSpec {
+  name: string;
+  required: boolean;
+  type: string;
+  description: string;
+  example: string;
+  notes?: string;
+}
+
+const CSV_COLUMNS: CsvColumnSpec[] = [
+  {
+    name: 'Date',
+    required: true,
+    type: 'YYYY-MM-DD',
+    description: 'Observation date — when this snapshot was recorded.',
+    example: '2026-04-15',
+    notes: 'Must use four-digit year, dash separator. Other formats will be rejected.',
+  },
+  {
+    name: 'Item_ID',
+    required: false,
+    type: 'integer',
+    description: 'Unique numeric ID for this item. Optional — the system can assign one.',
+    example: '1',
+  },
+  {
+    name: 'Item_Name',
+    required: true,
+    type: 'text',
+    description: 'Display name of the inventory item.',
+    example: 'Fresh Milk',
+    notes: 'Use a name distinct enough to identify the item in reports.',
+  },
+  {
+    name: 'Category',
+    required: false,
+    type: 'text',
+    description: 'High-level grouping (e.g., Dairy, Produce, Bakery).',
+    example: 'Dairy',
+  },
+  {
+    name: 'Subcategory',
+    required: false,
+    type: 'text',
+    description: 'Specific grouping within the category.',
+    example: 'Milk Products',
+  },
+  {
+    name: 'Unit',
+    required: true,
+    type: 'text',
+    description: 'Unit of measure for stock and usage values.',
+    example: 'kg, liter, pcs, pack',
+  },
+  {
+    name: 'Current_Stock',
+    required: true,
+    type: 'number ≥ 0',
+    description: 'Quantity on hand right now, in the unit above.',
+    example: '25.5',
+    notes: 'Drives days-of-cover and urgency scoring.',
+  },
+  {
+    name: 'Reorder_Level',
+    required: false,
+    type: 'number ≥ 0',
+    description: 'Manual override for reorder threshold. Leave blank to auto-compute.',
+    example: '10',
+  },
+  {
+    name: 'Daily_Usage',
+    required: true,
+    type: 'number > 0',
+    description: 'Average quantity consumed per day.',
+    example: '5.2',
+    notes: 'Drives demand forecasting.',
+  },
+  {
+    name: 'Lead_Time',
+    required: true,
+    type: 'integer > 0',
+    description: 'Days between placing a replenishment order and receiving it.',
+    example: '3',
+    notes: 'Longer lead times raise the urgency score.',
+  },
+  {
+    name: 'Price_per_Unit',
+    required: true,
+    type: 'number ≥ 0',
+    description: 'Cost paid per unit, in your local currency.',
+    example: '4.50',
+    notes: 'Used to compute inventory value and waste-cost exposure.',
+  },
+  {
+    name: 'Supplier_Name',
+    required: false,
+    type: 'text',
+    description: 'Vendor name for this item.',
+    example: 'Local Farmer',
+  },
+  {
+    name: 'Seasonal_Factor',
+    required: true,
+    type: 'number ≥ 0',
+    description: 'Demand multiplier. 1.0 = normal, > 1.0 = peak season, < 1.0 = quieter.',
+    example: '1.0',
+    notes: 'Typical range: 0.8 to 1.5.',
+  },
+  {
+    name: 'Waste_Percentage',
+    required: true,
+    type: '0–100',
+    description: 'Percentage of stock recently wasted/spoiled.',
+    example: '5',
+    notes: 'Drives waste-risk scoring. Required if perishability is not provided separately.',
+  },
+];
 
 export default function EntryPage() {
   const router = useRouter();
@@ -17,6 +136,8 @@ export default function EntryPage() {
   const [mode, setMode] = useState<'upload' | 'manual' | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>('');
+  const [showColumnDetails, setShowColumnDetails] = useState(false);
+  const [tourOpen, setTourOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -24,6 +145,13 @@ export default function EntryPage() {
       router.push('/login');
     }
   }, [user, loading, router]);
+
+  useEffect(() => {
+    if (loading || !user) return;
+    if (shouldAutoOpenTour()) {
+      setTourOpen(true);
+    }
+  }, [loading, user]);
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -118,10 +246,21 @@ export default function EntryPage() {
 
       <div className="max-w-4xl mx-auto p-4 md:p-8">
         {/* Header */}
-        <div className="text-center mb-8 md:mb-12">
+        <div className="text-center mb-8 md:mb-12 relative">
           <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-2">StockWise</h1>
           <p className="text-base md:text-xl text-gray-600">Intelligent Inventory Analysis & Recommendations</p>
+          <button
+            type="button"
+            onClick={() => setTourOpen(true)}
+            className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:underline"
+            aria-label="Show quick tour"
+          >
+            <HelpCircle className="w-4 h-4" />
+            How does StockWise work?
+          </button>
         </div>
+
+        <GuidedTour open={tourOpen} onClose={() => setTourOpen(false)} />
 
         {/* Mode Selection or Selected Mode */}
         {!mode ? (
@@ -179,28 +318,106 @@ export default function EntryPage() {
 
             {/* CSV Format Help */}
             <div className="mt-12 bg-white rounded-lg p-6 shadow">
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">CSV Format Requirements</h3>
-              <p className="text-gray-600 mb-4">
-                Your CSV file should include the following columns:
-              </p>
-              <div className="bg-gray-50 P-4 rounded border border-gray-200 overflow-x-auto">
-                <pre className="text-xs text-gray-700 whitespace-pre-wrap break-words">
-                  Date,Item_ID,Item_Name,Category,Subcategory,Unit,Current_Stock,Reorder_Level,Daily_Usage,Lead_Time,Price_per_Unit,Supplier_Name,Seasonal_Factor,Waste_Percentage
-                </pre>
+              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">CSV Format Requirements</h3>
+                  <p className="text-gray-600 text-sm mt-1">
+                    Your CSV must include these 14 columns. Required columns are flagged below.
+                  </p>
+                </div>
+                <a
+                  href="/stockwise-example-template.csv"
+                  download="stockwise-example-template.csv"
+                  className="inline-flex items-center justify-center whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+                >
+                  Download CSV Template
+                </a>
               </div>
-              <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                <p className="text-gray-600 text-sm">
-                  * All 14 columns are required. Date should be in YYYY-MM-DD format. Numeric fields must contain valid numbers.
-                </p>
+
+              {/* Column reference table */}
+              <div className="overflow-x-auto -mx-2 sm:mx-0">
+                <table className="w-full text-sm border-collapse">
+                  <thead>
+                    <tr className="bg-gray-50 border-b border-gray-200">
+                      <th className="text-left py-2 px-3 font-semibold text-gray-700">Column</th>
+                      <th className="text-left py-2 px-3 font-semibold text-gray-700">Required</th>
+                      <th className="text-left py-2 px-3 font-semibold text-gray-700">Type</th>
+                      <th className="text-left py-2 px-3 font-semibold text-gray-700">What it means</th>
+                      {showColumnDetails && (
+                        <th className="text-left py-2 px-3 font-semibold text-gray-700">Example</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {CSV_COLUMNS.map((col) => (
+                      <React.Fragment key={col.name}>
+                        <tr className="border-b border-gray-100 hover:bg-gray-50">
+                          <td className="py-2 px-3 font-mono text-xs text-gray-900 align-top whitespace-nowrap">
+                            {col.name}
+                          </td>
+                          <td className="py-2 px-3 align-top">
+                            {col.required ? (
+                              <span className="inline-flex items-center gap-1 text-xs font-medium text-red-700">
+                                <CheckCircle2 className="w-3 h-3" />
+                                Required
+                              </span>
+                            ) : (
+                              <span className="text-xs text-gray-500">Optional</span>
+                            )}
+                          </td>
+                          <td className="py-2 px-3 text-xs text-gray-600 align-top whitespace-nowrap">{col.type}</td>
+                          <td className="py-2 px-3 text-gray-700 align-top">
+                            <div>{col.description}</div>
+                            {showColumnDetails && col.notes && (
+                              <div className="text-xs text-gray-500 mt-1 italic">{col.notes}</div>
+                            )}
+                          </td>
+                          {showColumnDetails && (
+                            <td className="py-2 px-3 align-top font-mono text-xs text-gray-700 whitespace-nowrap">
+                              {col.example}
+                            </td>
+                          )}
+                        </tr>
+                      </React.Fragment>
+                    ))}
+                  </tbody>
+                </table>
               </div>
-              <div className="mt-4"></div>
-              <a
-                href="/stockwise-example-template.csv"
-                download="stockwise-example-template.csv"
-                className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+
+              {/* Toggle details */}
+              <button
+                type="button"
+                onClick={() => setShowColumnDetails((v) => !v)}
+                className="mt-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
               >
-                Download CSV Template
-              </a>
+                {showColumnDetails ? (
+                  <>
+                    <ChevronUp className="w-4 h-4" />
+                    Hide examples & notes
+                  </>
+                ) : (
+                  <>
+                    <ChevronDown className="w-4 h-4" />
+                    Show examples & notes
+                  </>
+                )}
+              </button>
+
+              {/* Common pitfalls */}
+              <div className="mt-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm font-semibold text-amber-900 mb-1">Common pitfalls to avoid</p>
+                    <ul className="text-sm text-amber-800 space-y-1 list-disc list-inside">
+                      <li>Date must be <span className="font-mono">YYYY-MM-DD</span> (e.g. <span className="font-mono">2026-04-15</span>) — not <span className="font-mono">DD/MM/YYYY</span>.</li>
+                      <li>Numeric fields cannot contain currency symbols (use <span className="font-mono">4.50</span>, not <span className="font-mono">RM4.50</span>).</li>
+                      <li>Empty rows or stray commas at end of lines will be rejected.</li>
+                      <li>Column headers must match exactly — case-sensitive (use the template if unsure).</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
             </div>
           </>
         ) : mode === 'upload' ? (

--- a/frontend/src/pages/methodology.tsx
+++ b/frontend/src/pages/methodology.tsx
@@ -1,0 +1,383 @@
+import React, { useEffect, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import {
+    ArrowLeft,
+    ArrowRight,
+    Calculator,
+    CheckCircle2,
+    Database,
+    Layers,
+    Shield,
+    Sparkles,
+    Target,
+} from 'lucide-react';
+import { NavigationBar } from '@/components/Dashboard';
+import { Button, Card } from '@/components/common';
+import { getLatestAnalysisId } from '@/lib/analysisSession';
+
+const PIPELINE_STAGES = [
+    {
+        title: '1. Data Intake',
+        icon: <Database className="w-5 h-5" />,
+        body: 'CSV upload or manual entry. Each record is validated against a strict schema (required columns, types, ranges). Invalid rows are rejected with a clear error message.',
+        accent: 'bg-blue-50 border-blue-200 text-blue-900',
+        iconBg: 'bg-blue-100 text-blue-700',
+    },
+    {
+        title: '2. Deterministic Scoring',
+        icon: <Calculator className="w-5 h-5" />,
+        body: 'Backend computes metrics (days of cover, lead-time demand, inventory value, etc.) and two scores (Reorder Urgency, Waste Risk) using fixed mathematical formulas. No AI is involved here.',
+        accent: 'bg-emerald-50 border-emerald-200 text-emerald-900',
+        iconBg: 'bg-emerald-100 text-emerald-700',
+    },
+    {
+        title: '3. Action Classification',
+        icon: <Target className="w-5 h-5" />,
+        body: 'Each item is assigned exactly one action label — RESTOCK_NOW, BUY_LESS, DELAY_PURCHASE, or MONITOR_CLOSELY — based on the two scores. Same inputs always produce the same label.',
+        accent: 'bg-amber-50 border-amber-200 text-amber-900',
+        iconBg: 'bg-amber-100 text-amber-700',
+    },
+    {
+        title: '4. AI Explanation Layer',
+        icon: <Sparkles className="w-5 h-5" />,
+        body: 'GLM (Z.AI) generates plain-language rationale using the already-computed metrics. AI does not change the recommendation — it explains it. JSON-validated; one strict retry; deterministic fallback if invalid.',
+        accent: 'bg-purple-50 border-purple-200 text-purple-900',
+        iconBg: 'bg-purple-100 text-purple-700',
+    },
+];
+
+const COMPUTED_METRICS = [
+    {
+        name: 'days_of_cover',
+        formula: 'current_stock / daily_usage',
+        meaning: 'How many days the current stock will last at the current usage rate.',
+    },
+    {
+        name: 'inventory_value',
+        formula: 'current_stock × price_per_unit',
+        meaning: 'Cash currently tied up in this item.',
+    },
+    {
+        name: 'estimated_waste_cost',
+        formula: 'inventory_value × (waste_percentage / 100)',
+        meaning: 'Cash exposure from anticipated spoilage.',
+    },
+    {
+        name: 'lead_time_demand',
+        formula: 'daily_usage × lead_time × seasonal_factor',
+        meaning: 'Quantity that will be consumed before the next replenishment arrives.',
+    },
+    {
+        name: 'stock_gap_to_lead_demand',
+        formula: 'current_stock − lead_time_demand',
+        meaning: 'Negative values mean a stockout is likely before resupply.',
+    },
+    {
+        name: 'avg_usage_7d & trend_direction',
+        formula: 'mean(last 7 days) and direction (up/down/stable)',
+        meaning: 'Recent demand momentum, used in the Records view.',
+    },
+];
+
+export default function MethodologyPage() {
+    const [dashboardHref, setDashboardHref] = useState<string>('/');
+
+    useEffect(() => {
+        const latestId = getLatestAnalysisId();
+        setDashboardHref(latestId ? `/dashboard/${latestId}` : '/');
+    }, []);
+
+    return (
+        <>
+            <Head>
+                <title>StockWise — How It Works</title>
+            </Head>
+            <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+                <NavigationBar activeSection="methodology" onFeatureSelect={() => null} />
+
+                <main className="max-w-5xl mx-auto p-4 md:p-8 space-y-8">
+                    {/* Hero */}
+                    <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                            <div className="inline-flex items-center gap-2 mb-3 px-3 py-1 rounded-full bg-indigo-100 text-indigo-700 text-xs font-medium">
+                                <Layers className="w-3.5 h-3.5" />
+                                Methodology
+                            </div>
+                            <h1 className="text-3xl md:text-4xl font-bold text-slate-900 mb-3">
+                                How StockWise Decides
+                            </h1>
+                            <p className="text-base md:text-lg text-gray-600 max-w-3xl">
+                                Every recommendation you see is the result of a four-stage pipeline: validated data,
+                                deterministic scoring, rule-based classification, and an AI explanation layer.
+                                <span className="font-medium text-slate-900"> The AI does not pick the action — it explains the math.</span>
+                            </p>
+                        </div>
+                        <Link href={dashboardHref} className="flex-shrink-0">
+                            <Button variant="secondary" className="inline-flex items-center gap-1.5 whitespace-nowrap">
+                                <ArrowLeft className="w-4 h-4" />
+                                Back to Dashboard
+                            </Button>
+                        </Link>
+                    </div>
+
+                    {/* Pipeline */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">The pipeline</h2>
+                        <p className="text-sm text-gray-600 mb-5">
+                            Data flows left-to-right. Stages 1–3 are deterministic; stage 4 is the AI layer.
+                        </p>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {PIPELINE_STAGES.map((stage, idx) => (
+                                <div
+                                    key={stage.title}
+                                    className={`rounded-lg border p-4 ${stage.accent} relative`}
+                                >
+                                    <div className={`inline-flex items-center justify-center w-8 h-8 rounded-lg mb-3 ${stage.iconBg}`}>
+                                        {stage.icon}
+                                    </div>
+                                    <h3 className="font-semibold text-base mb-1">{stage.title}</h3>
+                                    <p className="text-sm leading-relaxed opacity-90">{stage.body}</p>
+                                    {idx < PIPELINE_STAGES.length - 1 && (
+                                        <ArrowRight className="hidden md:block absolute -right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 bg-white rounded-full" />
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    </Card>
+
+                    {/* What goes in */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">What you provide</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Eight required inputs per item (with three optional waste / category fields).
+                            See the{' '}
+                            <Link href="/" className="text-indigo-600 hover:underline">
+                                CSV format reference on the home page
+                            </Link>{' '}
+                            for the full schema.
+                        </p>
+                        <div className="grid gap-2 sm:grid-cols-2 text-sm">
+                            {[
+                                { name: 'item_name', desc: 'identifier' },
+                                { name: 'current_stock', desc: 'how much is on hand' },
+                                { name: 'unit', desc: 'kg, liter, pieces, etc.' },
+                                { name: 'usage_value + period', desc: 'consumption rate' },
+                                { name: 'lead_time_days', desc: 'days to receive an order' },
+                                { name: 'price_per_unit', desc: 'cost per unit' },
+                                { name: 'seasonal_factor', desc: 'demand multiplier (typ. 0.8–1.5)' },
+                                { name: 'waste signal', desc: 'perishability OR recent waste %' },
+                            ].map((field) => (
+                                <div key={field.name} className="flex items-baseline gap-2 p-2 rounded bg-slate-50">
+                                    <code className="text-xs font-mono text-slate-900 whitespace-nowrap">{field.name}</code>
+                                    <span className="text-gray-600 text-xs">{field.desc}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </Card>
+
+                    {/* Computed metrics */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">Stage 2a — Computed metrics</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            From your inputs, the backend computes six derived metrics. These are visible on every dashboard card.
+                        </p>
+                        <div className="overflow-x-auto -mx-2 sm:mx-0">
+                            <table className="w-full text-sm border-collapse">
+                                <thead>
+                                    <tr className="bg-slate-50 border-b border-slate-200">
+                                        <th className="text-left py-2 px-3 font-semibold text-gray-700">Metric</th>
+                                        <th className="text-left py-2 px-3 font-semibold text-gray-700">Formula</th>
+                                        <th className="text-left py-2 px-3 font-semibold text-gray-700">Meaning</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {COMPUTED_METRICS.map((m) => (
+                                        <tr key={m.name} className="border-b border-slate-100">
+                                            <td className="py-2 px-3 font-mono text-xs text-slate-900 align-top">{m.name}</td>
+                                            <td className="py-2 px-3 font-mono text-xs text-emerald-700 align-top">{m.formula}</td>
+                                            <td className="py-2 px-3 text-gray-700 align-top">{m.meaning}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </Card>
+
+                    {/* Scoring */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">Stage 2b — The two scores</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Both scores are bounded to the 0–100 range so they're comparable across items.
+                        </p>
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <div className="rounded-lg border border-rose-200 bg-rose-50 p-4">
+                                <h3 className="font-semibold text-rose-900 mb-2">Reorder Urgency Score</h3>
+                                <p className="text-sm text-rose-900 mb-3">
+                                    How critical it is to place an order now, weighted by stockout risk and item importance.
+                                </p>
+                                <div className="space-y-2 text-xs font-mono bg-white border border-rose-100 rounded p-3 leading-relaxed">
+                                    <div>
+                                        <span className="text-rose-700">stockout_risk</span> = (lead_time_demand − current_stock) / lead_time_demand
+                                    </div>
+                                    <div>
+                                        <span className="text-rose-700">reorder_gap</span> = (reorder_level − current_stock) / reorder_level
+                                    </div>
+                                    <div>
+                                        <span className="text-rose-700">importance</span> = 15·(usage_share) + 10·(lead_time_share)
+                                    </div>
+                                    <div className="pt-2 border-t border-rose-100">
+                                        <span className="text-rose-900 font-semibold">urgency</span> = 50·stockout_risk + 25·reorder_gap + importance·multiplier
+                                    </div>
+                                </div>
+                                <p className="text-xs text-rose-800 mt-2 italic">
+                                    Drops to 0 when current stock is significantly above the reorder level (overstocked).
+                                </p>
+                            </div>
+
+                            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+                                <h3 className="font-semibold text-amber-900 mb-2">Waste Risk Score</h3>
+                                <p className="text-sm text-amber-900 mb-3">
+                                    How likely it is the current stock will spoil before being used, weighted against urgency.
+                                </p>
+                                <div className="space-y-2 text-xs font-mono bg-white border border-amber-100 rounded p-3 leading-relaxed">
+                                    <div>
+                                        <span className="text-amber-700">base_waste</span> = waste_percentage × 10
+                                    </div>
+                                    <div>
+                                        <span className="text-amber-700">discount</span> = urgency_score × 0.25
+                                    </div>
+                                    <div>
+                                        <span className="text-amber-700">overstock_ratio</span> = clamp((days_of_cover − expected_cover) / threshold)
+                                    </div>
+                                    <div className="pt-2 border-t border-amber-100">
+                                        <span className="text-amber-900 font-semibold">waste_risk</span> = (base_waste − discount) + 65·overstock_ratio
+                                    </div>
+                                </div>
+                                <p className="text-xs text-amber-800 mt-2 italic">
+                                    High urgency reduces waste risk — if you need to reorder soon, you won't waste current stock.
+                                </p>
+                            </div>
+                        </div>
+                    </Card>
+
+                    {/* Action classification */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">Stage 3 — Action classification</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            Rules applied in order. The first match wins. Same inputs always produce the same action.
+                        </p>
+                        <div className="space-y-2">
+                            {[
+                                {
+                                    rule: 'urgency ≥ 55  OR  stock_gap_to_lead_demand < 0',
+                                    action: 'RESTOCK_NOW',
+                                    color: 'bg-rose-100 text-rose-800 border-rose-200',
+                                },
+                                {
+                                    rule: 'waste_risk ≥ 60  AND  urgency < 55',
+                                    action: 'BUY_LESS',
+                                    color: 'bg-amber-100 text-amber-800 border-amber-200',
+                                },
+                                {
+                                    rule: 'urgency ≤ 35  AND  waste_risk ≤ 45',
+                                    action: 'DELAY_PURCHASE',
+                                    color: 'bg-emerald-100 text-emerald-800 border-emerald-200',
+                                },
+                                {
+                                    rule: 'otherwise',
+                                    action: 'MONITOR_CLOSELY',
+                                    color: 'bg-slate-100 text-slate-700 border-slate-200',
+                                },
+                            ].map((row) => (
+                                <div key={row.action} className="flex items-center gap-3 p-3 border rounded-lg bg-slate-50">
+                                    <code className="flex-1 text-xs text-gray-700">{row.rule}</code>
+                                    <ArrowRight className="w-4 h-4 text-gray-400 flex-shrink-0" />
+                                    <span className={`inline-flex items-center px-2 py-1 text-xs font-mono font-semibold rounded border ${row.color}`}>
+                                        {row.action}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </Card>
+
+                    {/* AI's role */}
+                    <Card className="p-6">
+                        <h2 className="text-xl font-semibold text-slate-900 mb-1">Stage 4 — Where AI fits in</h2>
+                        <p className="text-sm text-gray-600 mb-4">
+                            AI is a presentation layer over deterministic scoring. It writes the &quot;why&quot;, not the &quot;what&quot;.
+                        </p>
+
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <div className="p-4 rounded-lg border-2 border-emerald-200 bg-emerald-50">
+                                <h3 className="font-semibold text-emerald-900 mb-2 flex items-center gap-2">
+                                    <CheckCircle2 className="w-4 h-4" />
+                                    What AI does
+                                </h3>
+                                <ul className="text-sm text-emerald-900 space-y-1.5 list-disc list-inside">
+                                    <li>Writes plain-language explanations of urgency &amp; waste scores</li>
+                                    <li>Generates the dashboard-level Decision Brief</li>
+                                    <li>Powers the AI Copilot Chat (grounded to current analysis)</li>
+                                    <li>Translates technical metrics into actionable language</li>
+                                </ul>
+                            </div>
+                            <div className="p-4 rounded-lg border-2 border-rose-200 bg-rose-50">
+                                <h3 className="font-semibold text-rose-900 mb-2">What AI does not do</h3>
+                                <ul className="text-sm text-rose-900 space-y-1.5 list-disc list-inside">
+                                    <li>Compute scores — those are deterministic Python formulas</li>
+                                    <li>Choose the action — that&apos;s rule-based classification</li>
+                                    <li>Modify inputs — your data is immutable in the pipeline</li>
+                                    <li>Hallucinate numbers — JSON-validated, strict retry, fallback ready</li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div className="mt-4 p-4 rounded-lg bg-indigo-50 border border-indigo-200">
+                            <h3 className="font-semibold text-indigo-900 mb-2 flex items-center gap-2">
+                                <Shield className="w-4 h-4" />
+                                Reliability guarantees
+                            </h3>
+                            <ul className="text-sm text-indigo-900 space-y-1.5 list-disc list-inside">
+                                <li><span className="font-medium">JSON validation:</span> every AI response is parsed against a strict schema before being shown.</li>
+                                <li><span className="font-medium">One strict retry:</span> if the first response is invalid, AI is re-prompted with stricter instructions.</li>
+                                <li><span className="font-medium">Deterministic fallback:</span> if AI fails twice, the system shows a deterministic explanation built from the same metrics — the user is never blocked.</li>
+                                <li><span className="font-medium">Mock mode:</span> the entire app runs without an AI provider, using fixture responses — useful for offline demos and CI.</li>
+                            </ul>
+                        </div>
+                    </Card>
+
+                    {/* Why this matters */}
+                    <Card className="p-6 bg-gradient-to-r from-slate-900 to-slate-800 text-white">
+                        <h2 className="text-xl font-semibold mb-3">Why this architecture</h2>
+                        <p className="text-sm text-slate-200 mb-4">
+                            Pure-LLM systems give different answers to the same question. SME owners need consistency.
+                            Our design separates <span className="font-medium text-white">decisions</span> (rule-based, auditable) from <span className="font-medium text-white">explanations</span> (LLM, friendly).
+                        </p>
+                        <div className="grid gap-3 sm:grid-cols-3 text-sm">
+                            <div>
+                                <p className="font-medium text-white">Trustable</p>
+                                <p className="text-slate-300 text-xs mt-1">Same inputs → same recommendation. Every time.</p>
+                            </div>
+                            <div>
+                                <p className="font-medium text-white">Auditable</p>
+                                <p className="text-slate-300 text-xs mt-1">Every score traces back to its formula and inputs.</p>
+                            </div>
+                            <div>
+                                <p className="font-medium text-white">Resilient</p>
+                                <p className="text-slate-300 text-xs mt-1">Works even when the LLM is down — with deterministic fallback.</p>
+                            </div>
+                        </div>
+                    </Card>
+
+                    {/* Footer link */}
+                    <div className="text-center text-sm text-gray-500 pb-4">
+                        <Link href="/judge-mode" className="text-indigo-600 hover:underline">
+                            See live system status →
+                        </Link>
+                    </div>
+                </main>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
Addresses three concerns from the mentoring session:

1. **"CSV entry is too confusing"** — replaced wall-of-column-names with a structured table (Column / Required / Type / Meaning) + amber "Common pitfalls" callout + toggle for examples & notes.
2. **"Let users know how the system works"** — new 5-step `GuidedTour` popup written in cafe-owner language. Auto-opens on first visit, replayable via "How does StockWise work?" help button on home.
3. **"Prove the analysis is accurate"** — new `/methodology` page (linked from the last tour step for the technically curious) showing the four-stage pipeline, formulas, and AI's role with a "← Back to Dashboard" button in the header.

## Files
- `frontend/src/components/GuidedTour.tsx` (new) — 5-step modal
- `frontend/src/pages/methodology.tsx` (new) — technical breakdown
- `frontend/src/pages/index.tsx` — CSV format help redesign + tour wiring

## Test plan
- [x] Local typecheck + jest pass (25/25)
- [ ] Smoke: clear `localStorage.stockwise-tour-seen-v1`, refresh `/`, verify tour auto-opens
- [ ] Smoke: complete tour, click "See full technical breakdown" from last step, verify `/methodology` loads
- [ ] Smoke: click "Back to Dashboard" on methodology, verify routing
- [ ] Smoke: scroll the home page CSV format help, click "Show examples & notes", verify expand